### PR TITLE
babelのcore-js系エラー対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "autoprefixer": "^10.2.5",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
+    "core-js": "3",
     "cssnano": "^4.1.10",
     "dart-sass": "^1.25.0",
     "eslint": "^7.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,6 +1962,11 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2:
     browserslist "^4.17.5"
     semver "7.0.0"
 
+core-js@3:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.1.tgz#7a9816dabd9ee846c1c0fe0e8fcad68f3709134e"
+  integrity sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"


### PR DESCRIPTION
## 概要
アロー関数を使うとエラーが出るので、
下記を参考にcore-js@3を追加。

https://qiita.com/riversun/items/63c5f08c8da604c5ec1a